### PR TITLE
Add a method to clear all registered handlers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,13 @@ mock.timeout    = 0;
 var callbacks = [];
 
 /**
+ * Unregister all callbacks
+ */
+mock.clearRoutes = function() {
+    callbacks.splice(0, callbacks.length)
+}
+
+/**
  * Mock
  */
 function mock(superagent) {

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,36 @@ request
 
 `mock.put()` and `mock.del()` methods works as well.
 
+### Teardown
+
+You can remove all of the route handlers by calling `mock.clearRoutes()`.  This is useful when defining temporary route handlers for unit tests.
+
+```js
+
+// Using the mocha testing framework
+define('My API module', function(){
+
+  beforeEach(function(){
+    // Guarentee each test knows exactly which routes are defined
+    mock.clearRoutes()
+  })
+
+  it('should GET /me', function(done){
+    mock.get('/me', function(){done()})
+    api.getMe()
+  })
+
+  it('should POST /me', function(done){
+    // The GET route handler no longer exists
+    // So there is no chance to see a false positive
+    // if the function actually calls GET /me
+    mock.post('/me', function(){done()})
+    api.saveMe()
+  })
+
+})
+```
+
 ### Note
 
 Sadly, but `request.send()` doesn't work :( Sorry

--- a/test.js
+++ b/test.js
@@ -113,6 +113,18 @@ describe('superagent mock', function() {
           done(err);
         });
     });
-  });
 
+    it('should clear registered routes', function(done) {
+      mock.get('http://example.com', function(req){
+        throw Error('Route handler was called');
+      });
+      mock.clearRoutes();
+      request
+        .get('http://example.com')
+        .end(function(err, res) {
+          done(err);
+        });
+    });
+
+  });
 });


### PR DESCRIPTION
This is useful as a clean up step at the end of individual unit tests.

I am looking at using your library to mock some server requests, but I would like to ensure that each test has a well defined set of route handlers.
