### PR TITLE
Feature/expose headers and send

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,41 +40,58 @@ mock.timeout = function () {
 
 ### Get
 
+You may set headers using the `mock.set()`.  To ensure header keys are not case sensitive,
+all keys will be transformed to lower case (see example).
+
 ```js
 mock.get('/topics/:id', function(req) {
   return {
     id: req.params.id,
-    content: 'Hello World!'
+    content: 'Hello World!',
+    headers: req.headers
   };
 });
 
 request
   .get('/topics/1')
+  .set({ 'X-Custom-Header': 'value of header' })
   .end(function(err, data) {
-    console.log(data); // { id: 1, content: 'Hello World' }
+    console.log(data); // { id: 1, content: 'Hello World', headers: { 'x-custom-header': 'value of header' } }
   })
 ;
 ```
 
+`mock.del()` works in a similar way.
+
 ### Post
+
+You may set the body of a `POST` request as the second parameter of `mock.post()`
+or in `mock.send()`.  Values set in `send()` will overwrite previously set values.
 
 ```js
 mock.post('/topics/:id', function(req) {
   return {
     id: req.params.id,
-    content: req.body.content
+    body: req.body
   };
 });
 
 request
-  .post('/topics/5', { content: 'Hello world' })
+  .post('/topics/5', {
+    content: 'I will be overwritten',
+    fromPost: 'Foo'
+  })
+  .send({
+    content: 'Hello world',
+    fromSend: 'Bar'
+  })
   .end(function(err, data) {
-    console.log(data); // { id: 5, content: 'Hello world' }
+    console.log(data); // { id: 5, content: 'Hello world', fromPost: 'Foo', fromSend: 'Bar' }
   })
 ;
 ```
 
-`mock.put()` and `mock.del()` methods works as well.
+`mock.put()` method works in a similar way.
 
 ### Teardown
 
@@ -105,10 +122,6 @@ define('My API module', function(){
 
 })
 ```
-
-### Note
-
-Sadly, but `request.send()` doesn't work :( Sorry
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ request
     fromSend: 'Bar'
   })
   .end(function(err, data) {
-    console.log(data); // { id: 5, content: 'Hello world', fromPost: 'Foo', fromSend: 'Bar' }
+    console.log(data); // { id: 5, body: { content: 'Hello world', fromPost: 'Foo', fromSend: 'Bar' } }
   })
 ;
 ```

--- a/test.js
+++ b/test.js
@@ -16,26 +16,43 @@ describe('superagent mock', function() {
     it('should mock for get', function(done) {
       mock.get('/topics/:id', function(req) {
         req.params.id.should.be.equal('1');
-        return { id: req.params.id };
+        req.headers['my-header'].should.be.equal('my-Value')
+        return {
+          id: req.params.id,
+          head: req.headers['my-header']
+        };
       });
-      request.get('/topics/1').end(function(_, data) {
-        data.should.have.property('id', '1');
-        done();
-      });
+      request.get('/topics/1')
+        .set('My-Header', 'my-Value')
+        .end(function(_, data) {
+          data.should.have.property('id', '1');
+          data.should.have.property('head', 'my-Value')
+          done();
+        })
+      ;
     });
 
     it('should mock for post', function(done) {
       mock.post('/topics/:id', function(req) {
         return {
           id: req.params.id,
-          content: req.body.content
+          content: req.body.content,
+          fromSend: req.body.fromSend,
+          head: req.headers['my-header']
         };
       });
       request
-        .post('/topics/5', { content: 'Hello world' })
+        .post('/topics/5', { content: 'Should not appear' })
+        .send({
+          fromSend: 'Hello universe',
+          content: 'Hello world'
+        })
+        .set('My-Header', 'my-Value')
         .end(function(_, data) {
           data.should.have.property('id', '5');
           data.should.have.property('content', 'Hello world');
+          data.should.have.property('fromSend', 'Hello universe');
+          data.should.have.property('head', 'my-Value');
           done();
         })
       ;
@@ -89,6 +106,7 @@ describe('superagent mock', function() {
           done(err);
         });
     });
+
     it('should work with custom timeout', function(done) {
       var startedAt = +new Date();
       mock.timeout = 100;
@@ -101,6 +119,7 @@ describe('superagent mock', function() {
           done(err);
         });
     });
+
     it('should work with custom timeout function', function(done) {
       var startedAt = +new Date();
       mock.timeout = function () { return 200; };


### PR DESCRIPTION
This is accomplished by creating a mock request parallel to the current
route being processed.  The mock request stores values passed by set()
and send() which are then passed to the function returned by
Route.match().

I would like this functionality because I would like to make sure my wrapper for `superagent` is setting the correct custom headers and filling in default values for the JSON body.

This PR also renames `Route.fn` to `Route.handler` and the `callbacks` collection to `routes`.  I believe these names more closely align with their purpose in this library.  I'm happy to remove the name changes if you don't like them.
