### PR TITLE
Fix mergeObjects

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,10 +215,10 @@ function value(val) {
  * @param ...obj object variable number of objects to merge
  */
 function mergeObjects() {
-  var out = {};
-  var p;
+  var out = {},
+      p;
 
-  for(var index in arguments) {
+  for(var index = 0; index < arguments.length; index++) {
     var arg = arguments[index]
     if(isObject(arg)) {
       for(var prop in arg) {


### PR DESCRIPTION
For some reason `mergeObjects` breaks in our environment but works in superagent-mocker tests.

In our case, the `arguments` object does not iterate with `for(var in arguments)`. Additionally, `Object.keys(arguments)` returns an empty array. This is in line with what I would expect from the `arguments` object.

I haven't been able to figure out why this does not break in superagent-mocker tests, but this fix works in both situations.
