### PR TITLE
Extend functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@
  */
 var pathtoRegexp = require('path-to-regexp');
 
-
 /**
  * Expose public API
  */
@@ -41,11 +40,23 @@ mock.clearRoutes = function() {
 };
 
 /**
+ * Map api method to http method
+ */
+var methodsMapping = {
+  get: 'GET',
+  post: 'POST',
+  put: 'PUT',
+  del: 'DELETE',
+  patch: 'PATCH'
+};
+
+/**
  * Unregister specific route
  */
 mock.clearRoute = function(method, url) {
+  method = methodsMapping[method] || method;
   routes = routes.filter(function(route) {
-    return route.url !== url && route.method.toLowerCase() !== method;
+    return !(route.url === url && route.method === method);
   });
 };
 
@@ -67,11 +78,13 @@ function mock(superagent) {
     }
   };
 
-  patch(superagent, 'get', 'GET', state);
-  patch(superagent, 'post', 'POST', state);
-  patch(superagent, 'put', 'PUT', state);
-  patch(superagent, 'patch', 'PATCH', state);
-  patch(superagent, 'del', 'DELETE', state);
+  // patch api methods (http)
+  for (var method in methodsMapping) {
+    if (methodsMapping.hasOwnProperty(method)) {
+      var httpMethod = methodsMapping[method];
+      patch(superagent, method, httpMethod, state);
+    }
+  }
 
   var reqProto = superagent.Request.prototype;
 

--- a/index.js
+++ b/index.js
@@ -28,12 +28,6 @@ mock.timeout    = 0;
 var routes = [];
 
 /**
- * List of methods to patch
- * @type {string[]}
- */
-var methods = ['get', 'post', 'put', 'patch', 'del'];
-
-/**
  * Original superagent methods
  * @type {{}}
  */
@@ -73,9 +67,11 @@ function mock(superagent) {
     }
   };
 
-  methods.forEach(function(method) {
-    patch(superagent, method, method.toUpperCase(), state);
-  });
+  patch(superagent, 'get', 'GET', state);
+  patch(superagent, 'post', 'POST', state);
+  patch(superagent, 'put', 'PUT', state);
+  patch(superagent, 'patch', 'PATCH', state);
+  patch(superagent, 'del', 'DELETE', state);
 
   var reqProto = superagent.Request.prototype;
 
@@ -131,7 +127,7 @@ function mock(superagent) {
 }
 
 mock.unmock = function(superagent) {
-  methods.forEach(function(method) {
+  ['get', 'post', 'put', 'patch', 'del'].forEach(function(method) {
     superagent[method] = originalMethods[method];
   });
 

--- a/index.js
+++ b/index.js
@@ -149,6 +149,8 @@ mock.unmock = function(superagent) {
   ['end', 'set', 'send'].forEach(function(method) {
     reqProto[method] = originalMethods[method];
   });
+
+  delete superagent._patchedBySuperagentMocker;
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ function mock(superagent) {
   var oldSet = reqProto.set;
   reqProto.set = function(key, val) {
     if (!state.current) {
-      return oldSet(key, val);
+      return oldSet.call(this, key, val);
     }
     // Recursively set keys if passed an object
     if (isObject(key)) {
@@ -94,17 +94,17 @@ function mock(superagent) {
     }
     state.request.headers[key.toLowerCase()] = val;
     return this;
-  }
+  };
 
   // Patch Request.send()
-  var oldSend = reqProto.send
+  var oldSend = reqProto.send;
   reqProto.send = function(data) {
     if (!state.current) {
-      return oldSend(data);
+      return oldSend.call(this, data);
     }
     state.request.body = mergeObjects(state.current.body, data);
     return this;
-  }
+  };
 
   return mock; // chaining
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ mock.get       = defineRoute.bind(null, 'GET');
 mock.post      = defineRoute.bind(null, 'POST');
 mock.put       = defineRoute.bind(null, 'PUT');
 mock.del       = defineRoute.bind(null, 'DELETE');
+mock.patch     = defineRoute.bind(null, 'PATCH');
 
 /**
  * Request timeout
@@ -31,7 +32,16 @@ var routes = [];
  */
 mock.clearRoutes = function() {
   routes.splice(0, routes.length)
-}
+};
+
+/**
+ * Unregister specific route
+ */
+mock.clearRoute = function(method, url) {
+  routes = routes.filter(function(route) {
+    return route.url !== url && route.method.toLowerCase() !== method;
+  });
+};
 
 /**
  * Mock
@@ -55,6 +65,7 @@ function mock(superagent) {
   patch(superagent, 'get', 'GET', state);
   patch(superagent, 'post', 'POST', state);
   patch(superagent, 'put', 'PUT', state);
+  patch(superagent, 'patch', 'PATCH', state);
   patch(superagent, 'del', 'DELETE', state);
 
   var reqProto = superagent.Request.prototype;

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ request
 ;
 ```
 
-`mock.put()` method works in a similar way.
+`mock.put()`, `mock.patch()` methods works in a similar way.
 
 ### Teardown
 
@@ -123,6 +123,24 @@ define('My API module', function(){
 
 })
 ```
+
+Or you can remove only one specified route (by method and url)
+
+```js
+// to register route
+mock.get('/me', function(){done()})
+
+...
+
+// to remove registered handler
+mock.clearRoute('get', '/me');
+
+```
+
+### Rollback library effect
+
+In some cases it will be useful to remove patches from superagent lib after using mocks.
+In this cases you can use ```mock.unmock()``` method, that will rollback all patches that ```mock(superagent)``` call make.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -63,6 +63,20 @@ describe('superagent mock', function() {
       ;
     });
 
+    it('should mock for patch', function(done) {
+      mock.patch('/topics/:id', function(req) {
+        return { id: req.params.id, content: req.body.content };
+      });
+      request
+        .patch('/topics/7', { id: 7, content: 'hello world, bitch!11' })
+        .end(function(_, data) {
+          data.should.have.property('id', '7');
+          data.should.have.property('content', 'hello world, bitch!11');
+          done();
+        })
+      ;
+    });
+
     it('should mock for delete', function(done) {
       mock.del('/topics/:id', function(req) {
         return { id: req.params.id, content: req.body.content };

--- a/test.js
+++ b/test.js
@@ -263,6 +263,11 @@ describe('superagent mock', function() {
       ;
     });
 
+    it('should remove patches by unmock()', function() {
+      mock.unmock(request);
+      (request._patchedBySuperagentMocker === void 0).should.be.true;
+    });
+
   });
 
 });

--- a/test.js
+++ b/test.js
@@ -11,7 +11,6 @@ var mock    = process.env.SM_COV
                 ? require('./index-cov')(request)
                 : require('./index')(request);
 
-
 describe('superagent mock', function() {
 
   beforeEach(function() {
@@ -153,6 +152,29 @@ describe('superagent mock', function() {
         });
     });
 
+    it('should clear registered specific route', function(done) {
+      mock
+        .get('/topics', noop)
+        .get('/posters', function() {
+          return { id: 7 };
+        });
+      mock.clearRoute('get', '/topics');
+      request
+        .get('/topics')
+        .end(function(err, res) {
+          should.throws(function() {
+            should.ifError(err);
+          }, /ECONNREFUSED/);
+
+          request
+            .get('/posters')
+            .end(function(_, data) {
+              data.should.have.property('id', 7);
+              done();
+            });
+        });
+    });
+
     it('should provide error when method throws', function(done) {
       var error = Error('This should be in the callback!');
       mock.get('http://example.com', function(req) {
@@ -231,7 +253,7 @@ describe('superagent mock', function() {
         return req.body;
       });
       request
-        .post('/topics/5', { content: 'Hello Universe'})
+        .post('/topics/5', { content: 'Hello Universe' })
         .send({ content: 'Hello world', title: 'Yay!' })
         .end(function(_, data) {
           data.should.have.property('title', 'Yay!');
@@ -244,8 +266,6 @@ describe('superagent mock', function() {
   });
 
 });
-
-
 
 /**
  * Just noop


### PR DESCRIPTION
- added support of "patch" method;
- added clearRoute method that remove registered before route by method and url;
- added unmock method (rollback patches in superagent);
- fixed contexts when called wrapped function.
