### PR TITLE
restor the response object

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,11 +96,7 @@ function mock(superagent) {
       setTimeout(function(request) {
         try {
           var response = current(request);
-          if (response.status !== 200) {
-            cb && cb(response, null);
-          } else {
-            cb && cb(null, response);
-          }
+          cb && cb(null, response);
         } catch (ex) {
           cb && cb(ex, null);
         }
@@ -223,15 +219,12 @@ Route.prototype.match = function(method, url, body) {
   }
   var route = this;
   return function(req) {
-    var handlerValue = route.handler({
+    return route.handler({
       url: url,
       params: params || {},
       body: mergeObjects(body, req.body),
       headers: req.headers
     });
-    return mergeObjects({
-      status: 200
-    }, handlerValue);
   };
 };
 

--- a/test.js
+++ b/test.js
@@ -183,17 +183,6 @@ describe('superagent mock', function() {
         });
     });
 
-    it('should support status code in response', function(done) {
-      mock.get('/topics/:id', function(req) {
-        return {body: {}, status: 500};
-      });
-      request.get('/topics/1')
-        .end(function(err, data) {
-          err.should.have.property('status', 500);
-          done();
-        });
-    });
-
     it('should support headers', function(done) {
       mock.get('/topics/:id', function(req) {
         return req.headers;


### PR DESCRIPTION
I'm strongly against to modify response object, for 2 reasons:
1. It will conflict with a response object has the same property "status".
2. It calls the `mergeObjects` function which forcely changes the response(maybe it's a string,array,number or sth else) to an object.That's really a bad thing!
