### PR TITLE
Allow non object data to be handled in the request body via `send()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,12 @@ function mock(superagent) {
     if (!state || !state.current) {
       return oldSend.call(this, data);
     }
-    state.request.body = mergeObjects(state.current.body, data);
+    if (isObject(data)) {
+      state.request.body = mergeObjects(state.current.body, data);
+    }
+    else {
+      state.request.body = data;
+    }
     return this;
   };
 
@@ -249,7 +254,7 @@ Route.prototype.match = function(method, url, body) {
     var handlerValue = route.handler({
       url: url,
       params: params || {},
-      body: mergeObjects(body, req.body),
+      body: isObject(req.body) ? mergeObjects(body, req.body) : req.body,
       headers: req.headers,
       query: req.query
     });

--- a/test.js
+++ b/test.js
@@ -274,6 +274,20 @@ describe('superagent mock', function() {
       ;
     });
 
+    it('should pass non-object data from send()', function(done) {
+      mock.post('/topics/:id', function(req) {
+        return { body: req.body };
+      });
+      request
+        .post('/topics/6')
+        .send('foo bar baz')
+        .end(function(_, data) {
+          should.equal(data.body, 'foo bar baz');
+          done();
+        })
+      ;
+    });
+
     it('should rewrite post() data by send()', function(done) {
       mock.post('/topics/:id', function(req) {
         return req.body;


### PR DESCRIPTION
I ran into an issue where I am sending a string as the request body in PUT and POST operations.  Previously the code handling `send()` was assuming the data was always json.
