### PR TITLE
Treat other 20x statuses (besides 200) as success

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function mock(superagent) {
       setTimeout(function(request) {
         try {
           var response = current(request);
-          if (response.status !== 200) {
+          if (!/20[0-6]/.test(response.status)) {
             // superagent puts status and response on the error it returns,
             // which should be an actual instance of Error
             // See http://visionmedia.github.io/superagent/#error-handling

--- a/test.js
+++ b/test.js
@@ -202,6 +202,18 @@ describe('superagent mock', function() {
         });
     });
 
+    it('should not treat a 204 as an error', function(done) {
+      mock.get('/topics/:id', function(req) {
+        return {status: 204};
+      });
+      request.get('/topics/1')
+        .end(function(err, data) {
+          should.not.exist(err);
+          data.should.have.property('status', 204);
+          done();
+        });
+    });
+
     it('should support status code in response', function(done) {
       mock.get('/topics/:id', function(req) {
         return {body: {}, status: 500};


### PR DESCRIPTION
Previously, if you had return a status of, say, 204, this library treated it as non-success and invoked the `end` callback with an error.

Documentation indicates that 200 through 206 are successful responses: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
