### PR TITLE
WIP: resolve gh-39

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,7 @@ function mock(superagent) {
           cb && cb(ex, null);
         }
       }, value(mock.timeout), state.request);
+      return this;
     } else {
       oldEnd.call(this, cb);
     }


### PR DESCRIPTION
This is part of, but not all of, resolving gh-39

---

Superagent allows you to abort requests by using `req.abort()`. The way this usually works is...

``` js
const req = superagent
   .get()
   .whatevs()
   .end();

// later on..
req.abort()
```

superagent-mocker doesn't return `this` from its mocked `end`, so this adds that back in. However, `req.abort` doesn't seem to be working, so I'm still investigating that.
