### PR TITLE
Mocking for the `field` method of superagent

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,6 +150,24 @@ function mock(superagent) {
     return this;
   };
 
+  // Patch Request.field()
+  var oldField = originalMethods.field = reqProto.field;
+  reqProto.field = function(key, val) {
+    var state = this._superagentMockerState;
+    if (!state || !state.current) {
+      return oldField.call(this, key, val);
+    }
+    // Recursively prop keys if passed an object
+    if (isObject(key)) {
+      for (var prop in key) {
+        this.field(prop, key[prop]);
+      }
+      return this;
+    }
+    state.request.body[key] = val;
+    return this;
+  };
+
   // Patch Request.query()
   var oldQuery = originalMethods.query = reqProto.query;
   reqProto.query = function(objectOrString) {


### PR DESCRIPTION
This is just a first step in implementation of mocking of the `field` function ([see docs](https://visionmedia.github.io/superagent/#multipart-requests)). This function is very useful when you are trying to send multipart form.

I just want to know, whether such improvements are interesting for you (as maintainers and owners)

Required for merge:

* [x] owner approvement
* [ ] tests
* [x] ????
